### PR TITLE
feature return to dashboard after reviewing

### DIFF
--- a/src/scripts/components/review.tsx
+++ b/src/scripts/components/review.tsx
@@ -4,7 +4,9 @@ import { Link } from 'react-router'
 import { ISolution, ISolutionDetails } from '../models'
 import { challenges } from '../challenges'
 
-interface PropTypes {}
+interface PropTypes {
+  router: any
+}
 interface StateTypes {
   reviewedSolutionId?: string | null 
   solution?: ISolutionDetails
@@ -108,6 +110,7 @@ class Review extends React.PureComponent<PropTypes, StateTypes> {
         Math.round((parseInt(clarity) + parseInt(simplicity) + parseInt(ingenuity)) / 3)
       )
       firebase.database().ref('solutionsDetails/' + reviewedSolutionId + '/reviews/' + userId).set({ clarity, simplicity, ingenuity, pros, cons })
+      this.props.router.replace('/')
     }
   } 
 


### PR DESCRIPTION
When user submits a review, redirect them to their dashboard.
Replace is used instead of push to avoid returning to already reviewed item.
Ideally there should be another screen that confirms that review was successfully sent.